### PR TITLE
[Bug] Customer queue when out of stock

### DIFF
--- a/src/models/supplies.ts
+++ b/src/models/supplies.ts
@@ -101,6 +101,11 @@ export class Supplies extends Phaser.Events.EventEmitter {
     }
 
     isOutOfSupplies(recipe: Recipe): boolean {
-        return this._lemon < recipe.lemon || this._sugar < recipe.sugar || this._ice < recipe.ice || this._cup < 1;
+        return (
+            this._lemon < recipe.lemon ||
+            this._sugar < recipe.sugar ||
+            this._ice < recipe.ice * recipe.cupsPerPitcher ||
+            this._cup < 1
+        );
     }
 }

--- a/src/scenes/day-scene.ts
+++ b/src/scenes/day-scene.ts
@@ -211,12 +211,7 @@ export class DayScene extends Scene {
 
     makeLemonade({ disableDelay }: { disableDelay?: boolean } = { disableDelay: false }) {
         // check if there are enough supplies
-        if (
-            this.supplies.lemon < this.recipe.lemon ||
-            this.supplies.sugar < this.recipe.sugar ||
-            this.supplies.ice < this.recipe.ice * this.recipe.cupsPerPitcher ||
-            this.supplies.cup < 1
-        ) {
+        if (this.supplies.isOutOfSupplies(this.recipe)) {
             return;
         }
 


### PR DESCRIPTION
Issue: https://github.com/Gamez0/lemonade-tycoon/issues/23

- supplies class isOutOfOrder was the problem.
- recipe.ice times cupsPerPitcher when comparing with supplies