### PR TITLE
fix(recipe): remove dead off() call in constructor

### DIFF
--- a/src/models/recipe.ts
+++ b/src/models/recipe.ts
@@ -26,8 +26,6 @@ export class Recipe extends Phaser.Events.EventEmitter {
 
         this.on("change", this.updateCostPerCup, this);
         this.supplies.on("averagePriceChanged", this.updateCostPerCup, this);
-
-        this.off("shutdown", this.onSceneShutdown, this);
     }
 
     private updateCostPerCup() {


### PR DESCRIPTION
Closes #65

## Changes
Remove `this.off("shutdown", this.onSceneShutdown, this)` from the `Recipe` constructor. No matching `this.on()` was ever registered, making this a no-op that misleads readers into thinking shutdown cleanup was handled here.

The `onSceneShutdown` method still exists and should be called from the scene's shutdown event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)