### PR TITLE
fix: fix typos destory() and peek()

### DIFF
--- a/src/models/customerQueue.ts
+++ b/src/models/customerQueue.ts
@@ -29,7 +29,7 @@ export default class CustomerQueue extends Phaser.Events.EventEmitter {
         }
     }
 
-    peak(): Customer | undefined {
+    peek(): Customer | undefined {
         if (this._queue.length > 0) {
             return this._queue[0];
         }

--- a/src/ui/text-button.ts
+++ b/src/ui/text-button.ts
@@ -49,7 +49,7 @@ export class TextButton extends Phaser.GameObjects.Container {
         return graphics;
     }
 
-    public destory() {
+    public destroy() {
         this.startButton.destroy();
         this.emptyButton.destroy();
         this.buttonWithRadius.destroy();


### PR DESCRIPTION
Closes #66, closes #67

## Changes
- `text-button.ts:52` — rename `destory()` to `destroy()`
- `customerQueue.ts:32` — rename `peak()` to `peek()` (standard queue terminology)

Neither method was called externally, so no callers to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)