### PR TITLE
fix(rent): remove button from container before destroying in updateRentButton

### DIFF
--- a/src/ui/location-carousel-with-rent-button.ts
+++ b/src/ui/location-carousel-with-rent-button.ts
@@ -123,7 +123,7 @@ export class LocationCarouselWithRentButton extends Phaser.GameObjects.Container
     }
 
     private updateRentButton(rentedLocation: RentedLocation) {
-        this.rentButton.destroy();
+        this.remove(this.rentButton, true);
         this.rentButton = new TextButton(
             this.scene,
             360,


### PR DESCRIPTION
Closes #68

## Problem
`updateRentButton()` called `this.rentButton.destroy()` on the old button but never removed it from the container's children list before adding a new one. Each time the user clicked prev/next in the location carousel, a destroyed button reference was left in the container.

## Fix
Replace `this.rentButton.destroy()` with `this.remove(this.rentButton, true)`.

`Container.remove(child, true)` removes the child from the container's list **and** destroys it in one call — the correct Phaser pattern for this case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)