### PR TITLE
fix(day-scene): clean up timers and event listeners on shutdown

### DIFF
--- a/src/scenes/day-scene.ts
+++ b/src/scenes/day-scene.ts
@@ -217,6 +217,16 @@ export class DayScene extends Scene {
             callbackScope: this,
             loop: true,
         });
+
+        this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+            this.timerEvent?.remove(false);
+            this.enterIntervalDuration?.remove(false);
+            this.queueIntervalDuration?.remove(false);
+            this.sellIntervalDuration?.remove(false);
+            this.lemonadePitcher.off("change");
+            this.customerQueue.off("change");
+            this.skipButton.off("pointerdown");
+        });
     }
 
     makeLemonade({ disableDelay }: { disableDelay?: boolean } = { disableDelay: false }) {


### PR DESCRIPTION
Closes #69

## Problem
`DayScene.create()` registered 4 `TimerEvent`s and 3 event listeners but had no shutdown handler. Every time the player completed a day and transitioned back to `PreparationScene`, these would leak.

## Fix
Add a `SHUTDOWN` event handler at the end of `create()`:

```ts
this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
    this.timerEvent?.remove(false);
    this.enterIntervalDuration?.remove(false);
    this.queueIntervalDuration?.remove(false);
    this.sellIntervalDuration?.remove(false);
    this.lemonadePitcher.off("change");
    this.customerQueue.off("change");
    this.skipButton.off("pointerdown");
});
```

`remove(false)` stops and removes the timer without dispatching its callback one final time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)