### PR TITLE
feat(results): implement Results tab with yesterday's data

### DIFF
--- a/src/scenes/preparation-scene.ts
+++ b/src/scenes/preparation-scene.ts
@@ -119,7 +119,8 @@ export class PreparationScene extends Scene {
             this.budget,
             this.supplies,
             this.rentedLocation,
-            this.recipe
+            this.recipe,
+            this.yesterdayResult
         );
         this.weatherNewsContainer = new WeatherNewsContainer(this, 512, 64, this._date, weatherForecast, news, true);
         const map = this.make.tilemap({ key: "park-map" });

--- a/src/ui/game-control-container.ts
+++ b/src/ui/game-control-container.ts
@@ -3,6 +3,7 @@ import { Budget } from "../models/budget";
 import { RentedLocation } from "../models/location";
 import Price from "../models/price";
 import { Recipe } from "../models/recipe";
+import Result from "../models/result";
 import { Supplies } from "../models/supplies";
 import { BuySuppliesContainer } from "./buy-supplies-container";
 import { MarketingContainer } from "./marketing-container";
@@ -50,7 +51,8 @@ export class GameControlContainer extends Phaser.GameObjects.Container {
         budget: Budget,
         supplies: Supplies,
         rentedLocation: RentedLocation,
-        recipe: Recipe
+        recipe: Recipe,
+        yesterdayResult?: Result
     ) {
         super(scene, x, y);
         const marginLeft = 16;
@@ -63,7 +65,7 @@ export class GameControlContainer extends Phaser.GameObjects.Container {
         this.budget = budget;
         this.supplies = supplies;
 
-        this.resultsContainer = new ResultsContainer(scene, marginLeft + padding, 64);
+        this.resultsContainer = new ResultsContainer(scene, marginLeft + padding, 64, yesterdayResult);
         this.rentContainer = new RentContainer(scene, marginLeft + padding, 64, rentedLocation);
         this.upgradesContainer = new UpgradesContainer(scene, marginLeft + padding, 64);
         this.staffContainer = new StaffContainer(scene, marginLeft + padding, 64);

--- a/src/ui/results-container.ts
+++ b/src/ui/results-container.ts
@@ -1,14 +1,35 @@
+import Result from "../models/result";
+import { DescriptionText } from "./description-text";
 import { TitleText } from "./title-text";
 
-const titles = ["Yesterday's Results", "Charts", "Profit & Loss", "Balance Sheet"];
-
 export class ResultsContainer extends Phaser.GameObjects.Container {
-    title: TitleText;
+    private title: TitleText;
 
-    constructor(scene: Phaser.Scene, x: number, y: number) {
+    constructor(scene: Phaser.Scene, x: number, y: number, yesterdayResult?: Result) {
         super(scene, x, y);
-        this.title = new TitleText(scene, 0, 0, titles[0]);
+        this.title = new TitleText(scene, 0, 0, "Yesterday's Results");
         this.add(this.title);
+
+        if (!yesterdayResult) {
+            const noResults = new DescriptionText(scene, 0, 40, "No results yet.\nStart your first day to see how it went!");
+            this.add(noResults);
+        } else {
+            const cupsSold = yesterdayResult.getCupsSold();
+            const revenue = yesterdayResult.getProfit();
+
+            const rows: [string, string][] = [
+                ["Cups Sold", `${cupsSold}`],
+                ["Revenue", `$${revenue.toFixed(2)}`],
+            ];
+
+            rows.forEach(([label, value], i) => {
+                const y = 50 + i * 40;
+                const labelText = new DescriptionText(scene, 0, y, label);
+                const valueText = new TitleText(scene, 240, y, value);
+                this.add([labelText, valueText]);
+            });
+        }
+
         scene.add.existing(this);
     }
 }


### PR DESCRIPTION
Closes #71

## Changes

### `ResultsContainer`
- Now accepts an optional `yesterdayResult?: Result`
- First day: shows "No results yet. Start your first day to see how it went!"
- Subsequent days: shows **Cups Sold** and **Revenue** from the previous day

### `GameControlContainer`
- Added `yesterdayResult?: Result` parameter and passes it through to `ResultsContainer`

### `PreparationScene`
- Passes `this.yesterdayResult` (already stored from `GameDataFromDayScene`) into `GameControlContainer`

## Data flow
```
DayScene.todayResult
  → GameDataFromDayScene.todayResult
  → PreparationScene.yesterdayResult
  → GameControlContainer
  → ResultsContainer
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)