### PR TITLE
refactor: register scenes statically and use scene.start() for transitions

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { GameOver } from "./scenes/GameOver";
 import { MainMenu as MainGame } from "./scenes/MainMenu";
 import { Preloader } from "./scenes/Preloader";
 import { DayScene } from "./scenes/day-scene";
+import { PreparationScene } from "./scenes/preparation-scene";
 
 import { Game, Types } from "phaser";
 
@@ -42,7 +43,7 @@ const config: Types.Core.GameConfig = {
         mode: Phaser.Scale.FIT,
         autoCenter: Phaser.Scale.CENTER_BOTH,
     },
-    scene: [Boot, Preloader, MainGame, GameOver, DayScene],
+    scene: [Boot, Preloader, MainGame, GameOver, DayScene, PreparationScene],
 };
 
 export default new Game(config);

--- a/src/scenes/MainMenu.ts
+++ b/src/scenes/MainMenu.ts
@@ -1,5 +1,4 @@
 import { Scene, GameObjects } from "phaser";
-import { PreparationScene } from "./preparation-scene";
 
 // Define the MainMenu class that extends Phaser's Scene class
 export class MainMenu extends Scene {
@@ -15,9 +14,6 @@ export class MainMenu extends Scene {
 
     // Create method to set up the scene's content
     create() {
-        const preparationScene = new PreparationScene("preparation");
-        this.scene.add("preparation", preparationScene);
-
         // background color is #18ae31
         this.cameras.main.setBackgroundColor("#18ae31");
 
@@ -39,7 +35,7 @@ export class MainMenu extends Scene {
             .setInteractive({ useHandCursor: true });
 
         this.startButton.on("pointerdown", () => {
-            this.scene.start("preparation");
+            this.scene.start("PreparationScene");
             this.startButton.disableInteractive();
         });
     }

--- a/src/scenes/day-scene.ts
+++ b/src/scenes/day-scene.ts
@@ -13,7 +13,7 @@ import WeatherNewsContainer from "../ui/weather-news-container";
 import MapContainer from "../ui/map-container";
 import { RentedLocation } from "../models/location";
 import { Recipe } from "../models/recipe";
-import { GameDataFromDayScene, GameDataFromPreparationScene, PreparationScene } from "./preparation-scene";
+import { GameDataFromDayScene, GameDataFromPreparationScene } from "./preparation-scene";
 import Price from "../models/price";
 import CustomerQueue from "../models/customerQueue";
 import LemonadePitcher from "../models/lemonadePitcher";
@@ -100,11 +100,8 @@ export class DayScene extends Scene {
 
     customerListByHour: CustomerListByHour;
 
-    sceneKey: string;
-
-    constructor(key: string) {
-        super({ key });
-        this.sceneKey = key;
+    constructor() {
+        super({ key: "DayScene" });
     }
 
     init(data: GameDataFromPreparationScene) {
@@ -338,7 +335,6 @@ export class DayScene extends Scene {
     }
 
     switchToPreparationScene() {
-        const preparationScene = new PreparationScene(`preparation-${this._date.getDateString()}`);
         const data: GameDataFromDayScene = {
             budget: this.budget,
             supplies: this.supplies,
@@ -348,12 +344,7 @@ export class DayScene extends Scene {
             price: this.price,
             todayResult: this.todayResult,
         };
-        this.scene.add(`preparation-${this._date.getDateString()}`, preparationScene, true, data);
-        this.scene.start(`preparation-${this._date.getDateString()}`);
-
-        this.scene.get(this.scene.key).sys.shutdown();
-        this.scene.stop(this.scene.key);
-        this.scene.remove(this.scene.key);
+        this.scene.start("PreparationScene", data);
     }
 
     createAnimation() {

--- a/src/scenes/preparation-scene.ts
+++ b/src/scenes/preparation-scene.ts
@@ -9,7 +9,6 @@ import { RentedLocation } from "../models/location";
 import WeatherNewsContainer from "../ui/weather-news-container";
 import WeatherForecast, { Atmosphere, Season, TemperatureByTime, TemperatureRanges, Time } from "../types/weather-forecast";
 import MapContainer from "../ui/map-container";
-import { DayScene } from "./day-scene";
 import _Date from "../models/_date";
 import { Recipe } from "../models/recipe";
 import Price from "../models/price";
@@ -55,11 +54,8 @@ export class PreparationScene extends Scene {
     mapContainer: MapContainer;
     speakerButton: Phaser.GameObjects.Image;
 
-    private sceneKey: string;
-
-    constructor(key: string) {
-        super({ key });
-        this.sceneKey = key;
+    constructor() {
+        super({ key: "PreparationScene" });
     }
 
     preload() {
@@ -130,14 +126,10 @@ export class PreparationScene extends Scene {
         this.startButton = new TextButton(this, 410, 700, "START GAME");
         this.startButton.setInteractive();
         this.startButton.on("pointerdown", () => {
-            // Check if the player has enough money to rent the location
             if (this.budget.amount < this.rentedLocation.getFee()) {
                 alert("You don't have enough money to rent the location.");
                 return;
             }
-            // Create a new instance of the DayScene
-            const dayScene = new DayScene(`day-${this._date.getDateString()}`);
-            // // Add the new instance to the scene manager
             const data: GameDataFromPreparationScene = {
                 budget: this.budget,
                 supplies: this.supplies,
@@ -148,11 +140,10 @@ export class PreparationScene extends Scene {
                 recipe: this.recipe,
                 price: this.price,
             };
-            this.scene.add(`day-${this._date.getDateString()}`, dayScene, true, data);
-            this.scene.start(`day-${this._date.getDateString()}`);
-            this.scene.get(this.sceneKey).sys.shutdown();
-            this.scene.stop(this.sceneKey);
-            this.scene.remove(this.sceneKey);
+            this.scene.start("DayScene", data);
+        });
+
+        this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
             this.sound.remove(this.bgm);
         });
     }


### PR DESCRIPTION
## Summary
- Add `PreparationScene` to static scene config in `main.ts`
- Replace dynamic scene instantiation (`new DayScene(\`day-${date}\`)`) with `this.scene.start(key, data)`
- Remove manual `sys.shutdown()` / `stop()` / `remove()` calls — Phaser handles this automatically
- Move BGM cleanup to `PreparationScene` shutdown handler
- Remove `constructor(key: string)` and `sceneKey` fields from both scenes

## Why
`PreparationScene` was never in the static config, so it had to be created manually. This pattern spread to all scene transitions. `scene.start(key, data)` is the idiomatic Phaser approach and does the same thing in one line.

## Test plan
- [ ] Start game from MainMenu → PreparationScene loads correctly
- [ ] Click START GAME → DayScene starts with correct data (budget, supplies, weather, etc.)
- [ ] Day ends → PreparationScene returns with yesterday's results shown
- [ ] BGM plays in PreparationScene, stops during DayScene, resumes next PreparationScene
- [ ] Speaker mute/unmute persists across scene transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)